### PR TITLE
Add ability to hit both "summary" and "events" tables from Starlark

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Administrative endpoints include
 | HTTP | Endpoint | Permissions | Desc                             |
 | ---- | -------- | ----------- | -------------------------------- |
 | GET  | /health  | any         | A standard healthcheck endpoint  |
-| GET  | /status  | admin         | Get server stats (RAM, GC, etc.) |
+| GET  | /status  | admin       | Get server stats (RAM, GC, etc.) |
 
 
 ## extending its-log

--- a/api/endpoints/etl_run_starlark.go
+++ b/api/endpoints/etl_run_starlark.go
@@ -19,10 +19,11 @@ import (
 
 func queryFun(etlP *types.RunEtlParams) func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	return func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var queryTable string
 		var queryString string
 		if err := starlark.UnpackArgs(
 			"config", args, kwargs,
-			"query", &queryString,
+			"table", &queryTable, "query", &queryString,
 		); err != nil {
 			return starlark.None, fmt.Errorf("config: %s", err)
 		}
@@ -53,18 +54,38 @@ func queryFun(etlP *types.RunEtlParams) func(_ *starlark.Thread, _ *starlark.Bui
 
 		resultList := starlark.NewList([]starlark.Value{})
 		for rows.Next() {
-			var row types.EventRow
-			if err := rows.Scan(&row.ID, &row.Timestamp, &row.KeyId, &row.Cluster, &row.Tags, &row.Value); err != nil {
-				return starlark.None, err
-			} else {
-				d := starlark.NewDict(10)
-				d.SetKey(starlark.String("id"), starlark.String(row.ID))
-				d.SetKey(starlark.String("timestamp"), starlark.String(row.Timestamp))
-				d.SetKey(starlark.String("key_id"), starlark.String(row.KeyId))
-				d.SetKey(starlark.String("cluster"), starlark.String(row.Cluster.String))
-				d.SetKey(starlark.String("tags"), starlark.String(row.Tags))
-				d.SetKey(starlark.String("value"), starlark.String(row.Value.String))
-				resultList.Append(d)
+			switch queryTable {
+			case "events":
+				var row types.EventRow
+				if err := rows.Scan(&row.ID, &row.Timestamp, &row.KeyId, &row.Cluster, &row.Tags, &row.Value); err != nil {
+					return starlark.None, err
+				} else {
+					d := starlark.NewDict(10)
+					d.SetKey(starlark.String("id"), starlark.String(row.ID))
+					d.SetKey(starlark.String("timestamp"), starlark.String(row.Timestamp))
+					d.SetKey(starlark.String("key_id"), starlark.String(row.KeyId))
+					d.SetKey(starlark.String("cluster"), starlark.String(row.Cluster.String))
+					d.SetKey(starlark.String("tags"), starlark.String(row.Tags))
+					d.SetKey(starlark.String("value"), starlark.String(row.Value.String))
+					resultList.Append(d)
+				}
+			case "summary":
+				var row types.SummaryRow
+				if err := rows.Scan(&row.ID, &row.LastRun, &row.Date, &row.KeyId, &row.Operation, &row.Tags, &row.Value, &row.Count, &row.Hash); err != nil {
+					return starlark.None, err
+				} else {
+					d := starlark.NewDict(10)
+					d.SetKey(starlark.String("id"), starlark.String(row.ID))
+					d.SetKey(starlark.String("last_run"), starlark.MakeInt64(row.LastRun))
+					d.SetKey(starlark.String("date"), starlark.String(row.KeyId))
+					d.SetKey(starlark.String("key_id"), starlark.String(row.KeyId))
+					d.SetKey(starlark.String("operation"), starlark.String(row.Operation))
+					d.SetKey(starlark.String("tags"), starlark.String(row.Tags.String))
+					d.SetKey(starlark.String("value"), starlark.String(row.Value.String))
+					d.SetKey(starlark.String("count"), starlark.Float(row.Count))
+					d.SetKey(starlark.String("hash"), starlark.String(row.Hash.String))
+					resultList.Append(d)
+				}
 			}
 		}
 
@@ -140,9 +161,9 @@ func etlRunStarlark(etlP *types.RunEtlParams, row models.GetETLRow, tx *sql.Tx) 
 			case "count":
 				v, found, _ := elem.(*starlark.Dict).Get(k)
 				if found {
-					var i int
-					_ = starlark.AsInt(v, &i)
-					srjs.Count = float64(i)
+					var f float64
+					f, _ = starlark.AsFloat(v)
+					srjs.Count = float64(f)
 
 				}
 			}

--- a/api/endpoints/serve.go
+++ b/api/endpoints/serve.go
@@ -148,11 +148,15 @@ func addSequenceEndpoints(rG *gin.RouterGroup) {
 
 // SUMMARY ENDPOINTS
 func addSummaryEndpoints(rG *gin.RouterGroup) {
-	auth_adminV1 := rG.Group("/")
-	permissions := []types.PermissionType{constants.Admin, constants.Test}
-	auth_adminV1.Use(AuthMiddleWare(permissions))
+	auth_adminV1ReadOnly := rG.Group("/")
+	auth_adminV1ReadWrite := rG.Group("/")
 
-	auth_adminV1.POST(constants.SUMMARY_READ, SummaryRead)
-	auth_adminV1.POST(constants.SUMMARY_CREATE, SummaryCreate)
+	permsRO := []types.PermissionType{constants.Admin, constants.ReadOnly, constants.Test}
+	permsRW := []types.PermissionType{constants.Admin, constants.Test}
+	auth_adminV1ReadOnly.Use(AuthMiddleWare(permsRO))
+	auth_adminV1ReadWrite.Use(AuthMiddleWare(permsRW))
+
+	auth_adminV1ReadOnly.POST(constants.SUMMARY_READ, SummaryRead)
+	auth_adminV1ReadWrite.POST(constants.SUMMARY_CREATE, SummaryCreate)
 
 }

--- a/api/internal/base/etl/sequence/full.sequence
+++ b/api/internal/base/etl/sequence/full.sequence
@@ -5,6 +5,8 @@
     { "name": "count-all-combinations" },
     { "name": "assert-source-and-total" },
     { "name": "count-vowels-and-consonants" },
+    { "name": "total-summary-count" },
+    { "name": "assert-event-summary-summation" },
     { "name": "hash-summaries" },
     { "name": "consolidate" },
     { "name": "backup" }

--- a/api/internal/base/etl/sql/assert-event-summary-summation.sql
+++ b/api/internal/base/etl/sql/assert-event-summary-summation.sql
@@ -1,0 +1,7 @@
+SELECT
+	(ABS(
+		(select count from itslog_summary
+			where operation = 'total.summary' and date = :date)
+		-
+		(select sum(count) as s from itslog_summary
+			where operation != 'total.summary' and date = :date)) > 0.1);

--- a/api/internal/base/etl/starlark/count-vowels-and-consonants.star
+++ b/api/internal/base/etl/starlark/count-vowels-and-consonants.star
@@ -11,7 +11,7 @@
 #     return [{"tags": "something.v3"}, {"tags": "another.v2"}]
 
 def summarize():
-    query_rows = query("SELECT * from itslog_events")
+    query_rows = query("events", "SELECT * from itslog_events")
     summaries = []
     total_vowels = 0
     total_consonants = 0

--- a/api/internal/base/etl/starlark/total-summary-count.star
+++ b/api/internal/base/etl/starlark/total-summary-count.star
@@ -1,0 +1,21 @@
+## Testing this locally
+# starlark internal/base/etl/starlark/total-summary-count.star
+
+# def query(table, s):
+#     print(s)
+#     return [{"tags": "something.v3", "count": 3 }, {"tags": "another.v2", "count": 5 }]
+
+def summarize():
+    query_rows = query("summary", "SELECT * from itslog_summary")
+    total = 0
+    for row in query_rows:
+        print("count:", row["count"])
+        total += row["count"]
+
+    result = [
+        {"operation": "total.summary", "count": total},
+    ]
+    print(result)
+    return result
+
+# print(summarize())

--- a/api/internal/schema/models/query.sql.go
+++ b/api/internal/schema/models/query.sql.go
@@ -340,7 +340,7 @@ func (q *Queries) ReadSummary(ctx context.Context, arg ReadSummaryParams) (ReadS
 const updateLastRun = `-- name: UpdateLastRun :exec
 UPDATE itslog_etl
   SET 
-    last_run = CURRENT_TIMESTAMP 
+    last_run = unixepoch() 
 WHERE 
   name = ?
 `

--- a/api/internal/schema/query.sql
+++ b/api/internal/schema/query.sql
@@ -86,7 +86,7 @@ LIMIT 1;
 -- name: UpdateLastRun :exec
 UPDATE itslog_etl
   SET 
-    last_run = CURRENT_TIMESTAMP 
+    last_run = unixepoch() 
 WHERE 
   name = ?;
 

--- a/api/internal/types/etl.go
+++ b/api/internal/types/etl.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"database/sql"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -21,8 +23,13 @@ type RunEtlParams struct {
 }
 
 type SummaryRow struct {
-	Operation string `json:"operation"`
-	Tags      string `json:"tags"`
-	Value     string `json:"value"`
-	Count     int64  `json:"count"`
+	ID        int64          `json:"id"`
+	LastRun   int64          `json:"last_run"`
+	Date      string         `json:"date"`
+	KeyId     string         `json:"key_id"`
+	Operation string         `json:"operation"`
+	Tags      sql.NullString `json:"tags"`
+	Value     sql.NullString `json:"value"`
+	Count     float64        `json:"count"`
+	Hash      sql.NullString `json:"hash"`
 }

--- a/docs/etl-howto.md
+++ b/docs/etl-howto.md
@@ -114,7 +114,9 @@ The purpose of this ETL action is to pass quietly if the previous actions did th
 2. It is hermetic. Starlark programs cannot write to disk, talk to the network, or generally break out of their sandbox.
 3. It is Python-like. Starlark looks like and generally behaves like a subset of Python.
 
-All Starlark ETL actions have access to one magic function: `query()`. This function takes a string and returns a list of dictionaries. The string is an SQL statement that will be executed in the context of the current database, and the dictionaries have keys matching the columns of of the table queried; all values come back as strings. (FIXME: currently, this *only* works on the `events` table; `its-log` needs to be updated so that queries can be run against `events` or `summary`.)
+All Starlark ETL actions have access to one magic function: `query()`. This function takes two string arguments. The first is the table you want to query (either `"events"` or `"summary"`), and an SQL query appropriate for that table. The `query(table, sql)` function returns a list of dictionaries.
+
+The string is an SQL statement that will be executed in the context of the current database against the table specified, and the dictionaries have keys matching the columns of of the table queried; all values come back as either strings or integers, depending on the column type in the table schema. 
 
 The data returned can be analyzed/processed arbitrarily, and it is expected that a list of dictionaries will be returned matching the shape of `summary` rows. That data will be processed and inserted after the Starlark code executes.
 


### PR DESCRIPTION
This adds the ability to chose the table based on an additional param to `query()`. Adds some additional ETL actions, which are then hit by the `full` E2E sequence, and therefore covered under standard E2E testing.

Docs updated accordingly.

Broke out some read/write perms on the summary table endpoint; that may want further consideration.