### PR TITLE
Add `json`, `math`, and `time` standard libraries to Starlark interpreter

### DIFF
--- a/api/endpoints/etl_run_starlark.go
+++ b/api/endpoints/etl_run_starlark.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/navapbc/its-log/internal/schema/models"
 	"github.com/navapbc/its-log/internal/types"
+	"go.starlark.net/lib/json"
+	"go.starlark.net/lib/math"
+	"go.starlark.net/lib/time"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 )
@@ -104,12 +107,18 @@ func etlRunStarlark(etlP *types.RunEtlParams, row models.GetETLRow, tx *sql.Tx) 
 		return err
 	}
 
+	// The thread we'll execute the code in.
+	thread := &starlark.Thread{Name: row.Name + "-starlark-thread"}
+	// This loads standard modules, including JSON manipulation.
+	// See
+	// https://github.com/google/starlark-go/blob/fadfc96def35ea95e7f2bd9952256d4db1d80d91/cmd/starlark/starlark.go#L98
+	starlark.Universe["json"] = json.Module
+	starlark.Universe["time"] = time.Module
+	starlark.Universe["math"] = math.Module
+
 	// Register a query function
 	// This lets Starlark code call out and query the itslog_events table
 	registrar := starlark.StringDict{"query": starlark.NewBuiltin("query", queryFun(etlP))}
-
-	// The thread we'll execute the code in.
-	thread := &starlark.Thread{Name: row.Name + "-starlark-thread"}
 
 	// This evals the file, which does not *yet* execute the code.
 	// Note we register "query" as a function in the interpreted namespace.

--- a/api/internal/base/etl/starlark/sum-pocket-change.star
+++ b/api/internal/base/etl/starlark/sum-pocket-change.star
@@ -1,0 +1,31 @@
+## Testing this locally
+# starlark internal/base/etl/starlark/sum-pocket-change.star
+
+# def query(_, s):
+#     return [
+#         {"tags": "pocketchange", "value": '{"pennies": 3, "nickels": 5}'}, 
+#         ]
+
+def summarize():
+    query_rows = query("events", "SELECT * from itslog_events WHERE tags = 'pocketchange'")
+    sums = {
+        "pennies": 0,
+        "nickels": 0,
+        "dimes": 0,
+        "quarters": 0,
+    }
+    for row in query_rows:
+        # Convert the value field from JSON to a dictionary
+        d = json.decode(row["value"])
+        # Sum up what we find
+        for coin in ["pennies", "nickels", "dimes", "quarters"]:
+            if coin in d:
+                sums[coin] = sums[coin] + d[coin]
+    total = sums["pennies"] + (sums["nickels"] * 5) + (sums["dimes"] * 10) + (sums["quarters"] * 25)
+    result = [
+        {"operation": "total.pocketchange", "count": total},
+        {"operation": "total.pocketchange.json", "tags": json.encode(sums), "count": 0}
+    ]
+    return result
+
+# print(summarize())


### PR DESCRIPTION
This will add JSON handling to the Starlark interpreter.

We need authentic E2E tests for this, which will come with another ticket. A demo ETL that can be invoked manually was added for initial tests.